### PR TITLE
Add live profile for S3 bucket for storing mesos perl logs

### DIFF
--- a/groups/storage/profiles/live-eu-west-2/vars
+++ b/groups/storage/profiles/live-eu-west-2/vars
@@ -1,0 +1,2 @@
+aws_account = "live"
+


### PR DESCRIPTION
Principal devs require live access to perl logs whilst investigating an issue.

This is seen as a better solution than handing out the live pem key that cannot be revoked.

Liaising with Security on this issue.